### PR TITLE
Update GitHub URLs to iam-hussain/profanease-npm, move MCP deps to op…

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,6 +1,6 @@
 # Profanease — Full API Reference
 
-> Modern, lightweight profanity detection & content moderation toolkit for JavaScript/TypeScript. Zero dependencies at runtime. Detects l33t speak ($h1t→shit), Unicode homoglyphs (Cyrillic а→a), zero-width characters, and repeated character obfuscation (fuuuck→fuck). Ships with 25 language packs (tree-shakeable). Content categories for fine-grained guard rails. Custom word list support with no defaults. Works everywhere: Node.js ≥20, browsers, Deno, Bun, Cloudflare Workers.
+> Modern, lightweight profanity detection & content moderation toolkit for JavaScript/TypeScript. Zero runtime dependencies for the core library (MCP server requires optional peer deps). Detects l33t speak ($h1t→shit), Unicode homoglyphs (Cyrillic а→a), zero-width characters, and repeated character obfuscation (fuuuck→fuck). Ships with 25 language packs (tree-shakeable). Content categories for fine-grained guard rails. Custom word list support with no defaults. Works everywhere: Node.js ≥20, browsers, Deno, Bun, Cloudflare Workers.
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "profanease",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "profanease",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ZaHuPro/Profanease.git"
+    "url": "git+https://github.com/iam-hussain/profanease-npm.git"
   },
   "keywords": [
     "profanity",
@@ -75,12 +75,12 @@
     "ai-safety",
     "ai-guardrails"
   ],
-  "author": "ZaHuPro",
+  "author": "iam-hussain",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/ZaHuPro/Profanease/issues"
+    "url": "https://github.com/iam-hussain/profanease-npm/issues"
   },
-  "homepage": "https://github.com/ZaHuPro/Profanease#readme",
+  "homepage": "https://github.com/iam-hussain/profanease-npm#readme",
   "engines": {
     "node": ">=20"
   },
@@ -96,7 +96,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "optionalDependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^3.25.76"
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
     "profanease-mcp": "./dist/mcp-server.js"
   },
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.cjs",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.cts",
+    "!dist/**/*.map",
     "llms.txt",
     "llms-full.txt"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "profanease",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Modern, lightweight profanity detection & content moderation toolkit with l33t speak detection, multi-language support, and guard rails",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -33,7 +33,7 @@ const NORMALIZATION_VALUES = ['none', 'basic', 'moderate', 'aggressive'] as cons
 
 const server = new McpServer({
   name: 'profanease',
-  version: '2.0.1',
+  version: '2.0.2',
 });
 
 // ── Tool: check ──────────────────────────────────────────────

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -14,11 +14,11 @@ export default defineConfig([
     clean: true,
     target: 'es2022',
     splitting: false,
-    sourcemap: true,
+    sourcemap: false,
     outDir: 'dist',
     treeshake: true,
   },
-  // MCP server build: ESM only, no types needed
+  // MCP server build: ESM only, no types needed, externalize deps
   {
     entry: ['src/mcp-server.ts'],
     format: ['esm'],
@@ -29,6 +29,7 @@ export default defineConfig([
     sourcemap: false,
     outDir: 'dist',
     treeshake: true,
+    external: ['@modelcontextprotocol/sdk', 'zod'],
     async onSuccess() {
       const { readFileSync, writeFileSync, chmodSync } = await import('fs');
       const path = 'dist/mcp-server.js';


### PR DESCRIPTION
…tional

- Repository, bugs, and homepage URLs now point to iam-hussain/profanease-npm
- Author updated from ZaHuPro to iam-hussain
- Moved @modelcontextprotocol/sdk and zod to optionalDependencies so the core library stays zero-dep (MCP server deps only installed when needed)
- Fixed "zero dependencies" claim in llms-full.txt

https://claude.ai/code/session_015D2g11rsmaeyM8BepvdS1z